### PR TITLE
Convert deprecated curly brace access

### DIFF
--- a/block_mhaairs_util.php
+++ b/block_mhaairs_util.php
@@ -270,7 +270,7 @@ class MHUtil {
         $bin = "";
         $i = 0;
         do {
-            $bin .= chr(hexdec($str{$i}.$str{($i + 1)}));
+            $bin .= chr(hexdec($str[$i].$str[($i + 1)]));
             $i += 2;
         } while ($i < strlen($str));
         return $bin;

--- a/lib/Zend/Json/Decoder.php
+++ b/lib/Zend/Json/Decoder.php
@@ -321,7 +321,7 @@ class Zend_Json_Decoder
         $i          = $this->_offset;
         $start      = $i;
 
-        switch ($str{$i}) {
+        switch ($str[$i]) {
             case '{':
                $this->_token = self::LBRACE;
                break;
@@ -348,14 +348,14 @@ class Zend_Json_Decoder
                         break;
                     }
 
-                    $chr = $str{$i};
+                    $chr = $str[$i];
 
                     if ($chr == '\\') {
                         $i++;
                         if ($i >= $str_length) {
                             break;
                         }
-                        $chr = $str{$i};
+                        $chr = $str[$i];
                         switch ($chr) {
                             case '"' :
                                 $result .= '"';
@@ -428,7 +428,7 @@ class Zend_Json_Decoder
             return($this->_token);
         }
 
-        $chr = $str{$i};
+        $chr = $str[$i];
         if ($chr == '-' || $chr == '.' || ($chr >= '0' && $chr <= '9')) {
             if (preg_match('/-?([0-9])*(\.[0-9]*)?((e|E)((-|\+)?)[0-9]+)?/s',
                 $str, $matches, PREG_OFFSET_CAPTURE, $start) && $matches[0][1] == $start) {
@@ -491,7 +491,7 @@ class Zend_Json_Decoder
                     $i += 5;
                     break;
                 case ($ord_chrs_c >= 0x20) && ($ord_chrs_c <= 0x7F):
-                    $utf8 .= $chrs{$i};
+                    $utf8 .= $chrs[$i];
                     break;
                 case ($ord_chrs_c & 0xE0) == 0xC0:
                     // characters U-00000080 - U-000007FF, mask 110XXXXX
@@ -549,7 +549,7 @@ class Zend_Json_Decoder
             return mb_convert_encoding($utf16, 'UTF-8', 'UTF-16');
         }
 
-        $bytes = (ord($utf16{0}) << 8) | ord($utf16{1});
+        $bytes = (ord($utf16[0]) << 8) | ord($utf16[1]);
 
         switch (true) {
             case ((0x7F & $bytes) == $bytes):

--- a/lib/Zend/Json/Encoder.php
+++ b/lib/Zend/Json/Encoder.php
@@ -554,17 +554,17 @@ class Zend_Json_Encoder
             case 2:
                 // return a UTF-16 character from a 2-byte UTF-8 char
                 // see: http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
-                return chr(0x07 & (ord($utf8{0}) >> 2))
-                     . chr((0xC0 & (ord($utf8{0}) << 6))
-                         | (0x3F & ord($utf8{1})));
+                return chr(0x07 & (ord($utf8[0]) >> 2))
+                     . chr((0xC0 & (ord($utf8[0]) << 6))
+                         | (0x3F & ord($utf8[1])));
 
             case 3:
                 // return a UTF-16 character from a 3-byte UTF-8 char
                 // see: http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
-                return chr((0xF0 & (ord($utf8{0}) << 4))
-                         | (0x0F & (ord($utf8{1}) >> 2)))
-                     . chr((0xC0 & (ord($utf8{1}) << 6))
-                         | (0x7F & ord($utf8{2})));
+                return chr((0xF0 & (ord($utf8[0]) << 4))
+                         | (0x0F & (ord($utf8[1]) >> 2)))
+                     . chr((0xC0 & (ord($utf8[1]) << 6))
+                         | (0x7F & ord($utf8[2])));
         }
 
         // ignoring UTF-32 for now, sorry

--- a/lib/Zend/Loader/PluginLoader.php
+++ b/lib/Zend/Loader/PluginLoader.php
@@ -128,7 +128,7 @@ class Zend_Loader_PluginLoader implements Zend_Loader_PluginLoader_Interface
         }
 
         $last = strlen($prefix) - 1;
-        if ($prefix{$last} == '\\') {
+        if ($prefix[$last] == '\\') {
             return $prefix;
         }
 

--- a/lib/Zend/Validate/Isbn.php
+++ b/lib/Zend/Validate/Isbn.php
@@ -168,7 +168,7 @@ class Zend_Validate_Isbn extends Zend_Validate_Abstract
                 $isbn10 = str_replace($this->_separator, '', $value);
                 $sum    = 0;
                 for ($i = 0; $i < 9; $i++) {
-                    $sum += (10 - $i) * $isbn10{$i};
+                    $sum += (10 - $i) * $isbn10[$i];
                 }
 
                 // checksum
@@ -186,9 +186,9 @@ class Zend_Validate_Isbn extends Zend_Validate_Abstract
                 $sum    = 0;
                 for ($i = 0; $i < 12; $i++) {
                     if ($i % 2 == 0) {
-                        $sum += $isbn13{$i};
+                        $sum += $isbn13[$i];
                     } else {
-                        $sum += 3 * $isbn13{$i};
+                        $sum += 3 * $isbn13[$i];
                     }
                 }
                 // checksum


### PR DESCRIPTION
As suggested by [a comment on a gist designed to help with the deprecation](https://gist.github.com/theodorejb/763b83a43522b0fc1755a537663b1863#gistcomment-3254515), I used [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) to find and convert braces.

This should fix #16 